### PR TITLE
Revisited routing

### DIFF
--- a/code/pinpoint_app/lib/components/button.dart
+++ b/code/pinpoint_app/lib/components/button.dart
@@ -4,16 +4,16 @@ class ButtonWidget extends StatelessWidget {
   const ButtonWidget({
     super.key,
     required this.text,
-    required this.route,
+    required this.onTap,
   });
 
   final String text;
-  final String route;
+  final Function() onTap;
 
   @override
   Widget build(BuildContext context) {
     return GestureDetector(
-      onTap: () => {Navigator.pushNamed(context, route)},
+      onTap: onTap,
       child: Container(
         width: 200,
         padding: const EdgeInsets.all(25),

--- a/code/pinpoint_app/lib/main.dart
+++ b/code/pinpoint_app/lib/main.dart
@@ -1,6 +1,5 @@
 import 'package:flutter/material.dart';
 import 'package:pinpoint_app/screens/splash.dart';
-import 'package:pinpoint_app/screens/pinpoint/location.dart';
 
 void main() {
   runApp(const MyApp());
@@ -12,11 +11,8 @@ class MyApp extends StatelessWidget {
   // This widget is the root of your application.
   @override
   Widget build(BuildContext context) {
-    return MaterialApp(
-      home: const Splash(),
-      routes: {
-        '/location': (context) => const Location(),
-      },
+    return const MaterialApp(
+      home: Splash(),
     );
   }
 }

--- a/code/pinpoint_app/lib/screens/pinpoint/landing.dart
+++ b/code/pinpoint_app/lib/screens/pinpoint/landing.dart
@@ -1,0 +1,24 @@
+import 'package:flutter/material.dart';
+import 'package:pinpoint_app/components/button.dart';
+
+class PinpointLanding extends StatelessWidget {
+  const PinpointLanding(
+      {super.key,
+      required this.onButtonPressed});
+  final Function() onButtonPressed;
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+        child: Column(
+      mainAxisAlignment: MainAxisAlignment.center,
+      children: [
+        ButtonWidget(text: "My Location", onTap: onButtonPressed),
+        const SizedBox(
+          height: 25,
+        ),
+        const Text("PinPoint"),
+      ],
+    ));
+  }
+}

--- a/code/pinpoint_app/lib/screens/pinpoint/pinpoint.dart
+++ b/code/pinpoint_app/lib/screens/pinpoint/pinpoint.dart
@@ -1,23 +1,27 @@
 import 'package:flutter/material.dart';
-import 'package:pinpoint_app/components/button.dart';
+import 'package:pinpoint_app/screens/pinpoint/landing.dart';
+import 'package:pinpoint_app/screens/pinpoint/location.dart';
 
-class PinPoint extends StatelessWidget {
+class PinPoint extends StatefulWidget {
   const PinPoint({super.key});
 
   @override
+  State<PinPoint> createState() => _PinPointState();
+}
+
+class _PinPointState extends State<PinPoint> {
+  bool showPage1 = true;
+
+  void togglePages() {
+    setState(() {
+      showPage1 = !showPage1;
+    });
+  }
+
+  @override
   Widget build(BuildContext context) {
-    return const Scaffold(
-      body: Center(
-          child: Column(
-        mainAxisAlignment: MainAxisAlignment.center,
-        children: [
-          ButtonWidget(text: "My Location", route: "/location"),
-          SizedBox(
-            height: 25,
-          ),
-          Text("PinPoint"),
-        ],
-      )),
+    return Scaffold(
+      body: showPage1 ? PinpointLanding(onButtonPressed: togglePages) : const Location(),
     );
   }
 }


### PR DESCRIPTION
Instead of routing to new page, the pinpoint app now acts as a wrapper. Initially the landing.dart screen is shown. When the my location button is clicked, the location.dart screen will be shown.