### PR TITLE
User can now select desired floor plan

### DIFF
--- a/code/pinpoint_app/lib/models/floorplan.dart
+++ b/code/pinpoint_app/lib/models/floorplan.dart
@@ -1,0 +1,47 @@
+class Floorplan {
+  final String id;
+  final String name;
+  final Map<String, dynamic> location;
+  final String image;
+  late final Map<String, double> topLeft;
+  late final Map<String, double> bottomRight;
+
+  Floorplan({
+    required this.id,
+    required this.name,
+    required this.location,
+    required this.image,
+  }) {
+    // Extracting coordinates from location map
+    topLeft = {
+      'lat': location['topLeft']['lat'].toDouble(),
+      'lon': location['topLeft']['lon'].toDouble(),
+    };
+
+    bottomRight = {
+      'lat': location['bottomRight']['lat'].toDouble(),
+      'lon': location['bottomRight']['lon'].toDouble(),
+    };
+  }
+}
+
+List<Floorplan> hardcodedFloorplans = [
+  Floorplan(
+    id: '1',
+    name: 'Rock Werchter',
+    location: {
+      'topLeft': {'lat': 50.970008, 'lon': 4.681241},
+      'bottomRight': {'lat': 50.964636, 'lon': 4.689635},
+    },
+    image: 'assets/rw.png',
+  ),
+  Floorplan(
+    id: '2',
+    name: 'Pukkelpop',
+    location: {
+      'topLeft': {'lat': 50.965732, 'lon': 5.350469},
+      'bottomRight': {'lat': 50.952622, 'lon': 5.370038},
+    },
+    image: 'assets/pkp.png',
+  ),
+];

--- a/code/pinpoint_app/lib/screens/pinpoint/custom_map.dart
+++ b/code/pinpoint_app/lib/screens/pinpoint/custom_map.dart
@@ -2,44 +2,45 @@ import 'package:flutter/material.dart';
 import 'package:flutter_map/flutter_map.dart';
 import 'package:latlong2/latlong.dart';
 import 'package:pinpoint_app/screens/pinpoint/custom_map_overview.dart';
+import 'package:pinpoint_app/models/floorplan.dart';
 
 class MapTryout extends StatelessWidget {
-  const MapTryout({super.key});
+  final double centerLat;
+  final double centerLon;
+
+  const MapTryout({
+    Key? key,
+    required this.centerLat,
+    required this.centerLon,
+  }) : super(key: key);
 
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-        body: FlutterMap(
-      mapController: MapController(),
-      options: const MapOptions(
-          initialCenter: LatLng(50.96813, 4.68479), initialZoom: 14),
-      children: [
-        TileLayer(
-          urlTemplate: 'https://tile.openstreetmap.org/{z}/{x}/{y}.png',
+      body: FlutterMap(
+        mapController: MapController(),
+        options: MapOptions(
+          initialCenter: LatLng(centerLat, centerLon),
+          initialZoom: 14,
         ),
-        OverlayImageLayer(
-          overlayImages: [
-            OverlayImage(
-              bounds: LatLngBounds(
-                const LatLng(50.970008, 4.681241),
-                const LatLng(50.964636, 4.689635),
-              ),
-              imageProvider: const AssetImage(
-                "assets/rw.png",
-              ),
-            ),
-            OverlayImage(
-              bounds: LatLngBounds(
-                const LatLng(50.965732, 5.350469),
-                const LatLng(50.952622, 5.370038),
-              ),
-              imageProvider: const AssetImage(
-                "assets/pkp.png",
-              ),
-            ),
-          ],
-        ),
-        Padding(
+        children: [
+          TileLayer(
+            urlTemplate: 'https://tile.openstreetmap.org/{z}/{x}/{y}.png',
+          ),
+          OverlayImageLayer(
+            overlayImages: hardcodedFloorplans.map((floorplan) {
+              return OverlayImage(
+                bounds: LatLngBounds(
+                  LatLng(floorplan.location['topLeft']['lat'],
+                      floorplan.location['topLeft']['lon']),
+                  LatLng(floorplan.location['bottomRight']['lat'],
+                      floorplan.location['bottomRight']['lon']),
+                ),
+                imageProvider: AssetImage(floorplan.image),
+              );
+            }).toList(),
+          ),
+          Padding(
             padding: EdgeInsets.all(6),
             child: Row(
               mainAxisAlignment: MainAxisAlignment.end,
@@ -50,16 +51,22 @@ class MapTryout extends StatelessWidget {
                     Navigator.push(
                       context,
                       MaterialPageRoute(
-                          builder: (context) => CustomMapOverview()),
+                        builder: (context) => CustomMapOverview(),
+                      ),
                     );
                   },
                   backgroundColor: Color.fromRGBO(255, 255, 255, 1.0),
-                  child: const Icon(Icons.map,
-                      size: 40, color: Color.fromRGBO(30, 30, 30, 1.0)),
-                )
+                  child: const Icon(
+                    Icons.map,
+                    size: 40,
+                    color: Color.fromRGBO(30, 30, 30, 1.0),
+                  ),
+                ),
               ],
-            ))
-      ],
-    ));
+            ),
+          ),
+        ],
+      ),
+    );
   }
 }

--- a/code/pinpoint_app/lib/screens/pinpoint/pinpoint.dart
+++ b/code/pinpoint_app/lib/screens/pinpoint/pinpoint.dart
@@ -37,7 +37,7 @@ class _PinPointState extends State<PinPoint> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      body: showLocationPage ? const Location() : showMapPage ? const MapTryout() : PinpointLanding(onButtonLocationPressed: toggleLocationPage, onButtonMapPressed: toggleMapPage),
+      body: showLocationPage ? const Location() : showMapPage ? const MapTryout(centerLat: 50.967322, centerLon: 4.685438,) : PinpointLanding(onButtonLocationPressed: toggleLocationPage, onButtonMapPressed: toggleMapPage),
     );
   }
 }

--- a/code/pinpoint_app/lib/screens/search_events/search_events.dart
+++ b/code/pinpoint_app/lib/screens/search_events/search_events.dart
@@ -1,13 +1,74 @@
 import 'package:flutter/material.dart';
+import 'package:pinpoint_app/models/floorplan.dart';
+import 'package:pinpoint_app/screens/pinpoint/custom_map.dart';
 
 class SearchEvents extends StatelessWidget {
   const SearchEvents({super.key});
-
   @override
   Widget build(BuildContext context) {
-    return const Scaffold(
-      body: Center(
-        child: Text("Search Events")
+    return Scaffold(
+      body: Padding(
+        padding: const EdgeInsets.all(8.0),
+        child: ListView.builder(
+          itemCount: hardcodedFloorplans.length,
+          itemBuilder: (context, index) {
+            return GestureDetector(
+              onTap: () {
+                Floorplan floorplan = hardcodedFloorplans[index];
+                double centerLat =
+                    (floorplan.topLeft['lat']! + floorplan.bottomRight['lat']!) / 2;
+                double centerLon =
+                    (floorplan.topLeft['lon']! + floorplan.bottomRight['lon']!) / 2;
+
+                Navigator.push(
+                  context,
+                  MaterialPageRoute(
+                    builder: (context) => MapTryout(
+                      centerLat: centerLat,
+                      centerLon: centerLon,
+                    ),
+                  ),
+                );
+              },
+              child: Container(
+                  padding: EdgeInsets.only(top: 8.0, left: 8.0, right: 8.0),
+                  margin: EdgeInsets.only(bottom: 8.0),
+                  width: double.infinity,
+                  height: 200,
+                  decoration: BoxDecoration(
+                    color: Colors.red,
+                    borderRadius: BorderRadius.all(Radius.circular(10)),
+                  ),
+                  child: Center(
+                    child: Column(
+                      mainAxisAlignment: MainAxisAlignment.center,
+                      children: [
+                        Container(
+                          width: 100, // Set width and height as needed
+                          height: 100,
+                          decoration: BoxDecoration(
+                            shape: BoxShape.circle,
+                            color: Colors
+                                .white, // Set the desired background color
+                          ),
+                          child: ClipOval(
+                            child: Image.asset(
+                              hardcodedFloorplans[index].image,
+                              fit: BoxFit
+                                  .cover, // Adjust the fit based on your requirement
+                            ),
+                          ),
+                        ),
+                        SizedBox(
+                          height: 10,
+                        ),
+                        Text(hardcodedFloorplans[index].name)
+                      ],
+                    ),
+                  )),
+            );
+          },
+        ),
       ),
     );
   }


### PR DESCRIPTION
On the search event page (temporarly, has to be changed later on) a user can now find all the floorplans (events). On tapping an event card, the global map will open directly on the select floorplan (centerpoint calculated from topleft & bottomright coordinates)