### PR TITLE
Quick fix for when location hasn't been retrieved

### DIFF
--- a/code/pinpoint_app/lib/screens/pinpoint/custom_map.dart
+++ b/code/pinpoint_app/lib/screens/pinpoint/custom_map.dart
@@ -152,9 +152,9 @@ class _MapTryoutState extends State<MapTryout> {
                   heroTag: "toMyLocation",
                   onPressed: () {
                     mapController.move(
-                        LatLng(currentPosition!.latitude,
-                            currentPosition!.longitude),
-                        25.0);
+                        LatLng(currentPosition?.latitude ?? widget.centerLat,
+                            currentPosition?.longitude ?? widget.centerLon),
+                        22.0);
                   },
                   backgroundColor: const Color.fromRGBO(255, 255, 255, 1.0),
                   child: const Icon(


### PR DESCRIPTION
When trying to localize yourself but location hasn't been retrieved, an exception was thrown. Fix this by when location equals null, map is moved to the center of the event